### PR TITLE
removeSmallestComponents: Fix crash due to empty mesh

### DIFF
--- a/src/Algorithms/checkAndRepair.cpp
+++ b/src/Algorithms/checkAndRepair.cpp
@@ -786,6 +786,8 @@ int Basic_TMesh::removeSmallestComponents()
  Triangle *t, *t1, *t2, *t3;
  int nt = 0, gnt = 0;
 
+ if (T.numels() == 0) return 0;
+
  FOREACHTRIANGLE(t, n) UNMARK_BIT(t, 5);
 
  t = ((Triangle *)T.head()->data);


### PR DESCRIPTION
`removeSmallestComponents()` did not have the same empty-mesh
check as `removeSmallestComponents(double eps_area)` does.

This can lead to a segfault in

    t = ((Triangle *)T.head()->data);

and is also pointed out by valgrind as an `Invalid read of size 8`.