### PR TITLE
Do not treat already-formatted messages as format strings

### DIFF
--- a/src/Kernel/tmesh.cpp
+++ b/src/Kernel/tmesh.cpp
@@ -79,7 +79,7 @@ void TMesh::error(const char *msg, ...)
   display_message(fms, DISPMSG_ACTION_ERRORDIALOG);
  else
  {
-  fprintf(stderr,fms);
+  fputs(fms, stderr);
   exit(-1);
  }
 }
@@ -119,7 +119,7 @@ void TMesh::info(const char *msg, ...)
  if (display_message != NULL)
   display_message(fms, DISPMSG_ACTION_PUTMESSAGE);
  else
-  printf(fms);
+  fputs(fms, stdout);
 
  va_end(ap);
 }
@@ -218,7 +218,7 @@ bool TMesh::isUsingFiltering()
 void TMesh::addMessageToLogFile(const char *msg)
 {
 	FILE *fp = fopen("tmesh.log", "a");
-	fprintf(fp, msg);
+	fputs(msg, fp);
 	fclose(fp);
 }
 


### PR DESCRIPTION
Fixes compiling with `-Werror=format-security`.

I have not evaluated whether or not it was possible to craft a mesh file that would inject format specifiers into the formatted messages.

Considering that the I/O routines use unbounded functions like `strcpy` and `vsprintf` to build messages into fixed-size buffers, I am quite confident that this PR does not suffice make it safe to use MeshFix on untrusted inputs.

Still, this incremental improvement may be useful for some users.